### PR TITLE
Fix duplicate TransitType export

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,6 @@ export interface VBBLocation extends Station {}
 
 export type TransitProduct = 'suburban' | 'subway' | 'tram' | 'bus' | 'ferry' | 'express' | 'regional'
 
-export type TransitType = 'sbahn' | 'ubahn' | 'tram' | 'bus' | 'ferry' | 'express' | 'regional'
 
 export interface TransitLineDetails {
   name: string


### PR DESCRIPTION
## Summary
- remove redundant `TransitType` definition in `src/types.ts`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684443e7dd748325952750629112bc6a