### PR TITLE
Update Docker base images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ dist
 *.md
 .vscode
 .idea
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:24-alpine AS builder
+FROM node:24.1-alpine AS builder
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM nginx:alpine
+FROM nginx:1.27-alpine
 
 # Copy built files and config
 COPY --from=builder /app/dist /usr/share/nginx/html/


### PR DESCRIPTION
## Summary
- use Node 24.1 for the build stage
- update production base to nginx 1.27
- ignore coverage folder in docker builds

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6846a668b8cc83259d09ff563a56625f