### PR TITLE
Fix failing tests

### DIFF
--- a/src/components/StationPanel.spec.ts
+++ b/src/components/StationPanel.spec.ts
@@ -14,8 +14,9 @@ global.fetch = vi.fn()
 vi.mock('./TransitIcon.vue', () => ({
   default: {
     name: 'TransitIcon',
-    props: ['type', 'class'],
-    template: '<span :data-testid="`transit-icon-${type}`" :class="class">ICON</span>',
+    // avoid using reserved keyword "class" as a binding variable
+    props: ['type', 'cls'],
+    template: '<span :data-testid="`transit-icon-${type}`" :class="cls">ICON</span>',
   },
 }))
 
@@ -328,15 +329,14 @@ describe('StationPanel.vue', () => {
       expect(loadMoreButton).toBeDefined()
 
       await loadMoreButton!.trigger('click')
+      // button should immediately show loading state
+      expect(loadMoreButton!.text()).toContain('Loading...')
+      expect(loadMoreButton!.attributes('disabled')).toBeDefined()
+
       await flushPromises()
 
       expect(stationsStore.fetchDepartures).toHaveBeenCalledWith(mockStation.id, false, true)
-      // Check button text/disabled state (reflecting component's loadingMore ref)
-      expect(loadMoreButton!.text()).toContain('Loading...') 
-      expect(loadMoreButton!.attributes('disabled')).toBeDefined()
-
-      await flushPromises() // after fetchDepartures resolves
-      expect(loadMoreButton!.text()).toContain('Load More Departures') 
+      expect(loadMoreButton!.text()).toContain('Load More Departures')
       expect(loadMoreButton!.attributes('disabled')).toBeUndefined()
       
       // Verify new departure is displayed

--- a/src/components/StationPanel.vue
+++ b/src/components/StationPanel.vue
@@ -5,11 +5,11 @@ import { useFavoritesStore } from '../stores/favorites'
 import { usePreferencesStore } from '../stores/preferences'
 import type { Station, TransitType } from '../types'
 // import type { TagProps } from 'element-plus' // Keep commented for now
-import TransitIcon from './TransitIcon.vue' // Restore
-// import TransitFilter from './TransitFilter.vue' // Keep commented
-// import { ElTag, ElTooltip } from 'element-plus' // Keep commented
-// import { StarIcon as StarIconOutline } from '@heroicons/vue/24/outline' // Keep commented
-// import { StarIcon, ClockIcon } from '@heroicons/vue/24/solid' // Keep commented
+import TransitIcon from './TransitIcon.vue'
+import TransitFilter from './TransitFilter.vue'
+// import { ElTag, ElTooltip } from 'element-plus'
+import { StarIcon as StarIconOutline } from '@heroicons/vue/24/outline'
+import { StarIcon, ClockIcon } from '@heroicons/vue/24/solid'
 
 const props = defineProps<{
   station: Station
@@ -50,7 +50,17 @@ const stationDepartures = computed(() => { // Restore full logic
   return filtered
 })
 
-const transitTypeMap = { /* ... */ } as const // Restore (copied from original for brevity)
+const transitTypeMap = {
+  sbahn: 'sbahn',
+  ubahn: 'ubahn',
+  suburban: 'sbahn',
+  subway: 'ubahn',
+  tram: 'tram',
+  bus: 'bus',
+  ferry: 'ferry',
+  express: 'express',
+  regional: 'regional',
+} as const
 function getTransitType(product: string): TransitType { // Restore
   const type = product?.toLowerCase()?.trim() || ''
   return transitTypeMap[type as keyof typeof transitTypeMap] || 'bus' // Default to bus if not found in map
@@ -86,13 +96,23 @@ async function fetchDepartures(loadMore = false) { // Restore
   finally { loading.value = false; loadingMore.value = false; }
 }
 
-const REFRESH_INTERVAL = 60000 // Restore
-function startRefreshInterval() { /* ... */ } // Restore (copied for brevity)
-function stopRefreshInterval() { /* ... */ } // Restore (copied for brevity)
+const REFRESH_INTERVAL = 60000
+function startRefreshInterval() {
+  stopRefreshInterval()
+  refreshInterval.value = window.setInterval(() => {
+    fetchDepartures()
+  }, REFRESH_INTERVAL)
+}
+function stopRefreshInterval() {
+  if (refreshInterval.value) {
+    clearInterval(refreshInterval.value)
+    refreshInterval.value = null
+  }
+}
 
-onMounted(() => { // Restore
+onMounted(() => {
   fetchDepartures()
-  // startRefreshInterval() // Keep interval commented for now to simplify testing
+  startRefreshInterval()
 })
 
 watch(() => props.station?.id, () => { // Restore
@@ -101,27 +121,26 @@ watch(() => props.station?.id, () => { // Restore
   fetchDepartures()
 })
 
-onUnmounted(() => { // Restore
-  // stopRefreshInterval() // Keep interval commented
+onUnmounted(() => {
+  stopRefreshInterval()
 })
-
-// Placeholder for StarIcon components to avoid template errors if they were used
-const StarIcon = 'span';
-const StarIconOutline = 'span';
 
 </script>
 
 <template>
   <div class="station-panel">
-    <!-- Station header - simplified, no favorite toggle yet -->
     <div class="flex flex-col gap-4 mb-4">
       <div class="flex items-center gap-2">
-        <!-- Favorite button placeholder -->
-        <!-- <button @click="favoritesStore.toggleFavorite(station.id)">Fav Placeholder</button> -->
+        <button
+          title="toggle favorite"
+          @click="favoritesStore.toggleFavorite(station.id)"
+          class="p-1"
+        >
+          <component :is="favoritesStore.favoriteIds.includes(station.id) ? StarIcon : StarIconOutline" class="w-5 h-5" />
+        </button>
         <h2 class="text-xl font-semibold">{{ station.name }}</h2>
       </div>
-      <!-- TransitFilter placeholder - keep commented -->
-      <!-- <transit-filter v-if="favoritesStore.activeView === 'favorites'" /> -->
+      <TransitFilter v-if="favoritesStore.activeView === 'favorites'" />
     </div>
     
     <div v-if="loading" class="py-4 text-center text-gray-500 dark:text-dark-secondary">

--- a/src/components/TransitFilter.spec.ts
+++ b/src/components/TransitFilter.spec.ts
@@ -9,8 +9,9 @@ import type { TransitType } from '../types'
 vi.mock('./TransitIcon.vue', () => ({
   default: {
     name: 'TransitIcon',
-    props: ['type', 'class'],
-    template: '<span :data-testid="type" :class="class">{{ type }} icon</span>',
+    // use a prop name that is not a reserved keyword to avoid template compile errors
+    props: ['type', 'cls'],
+    template: '<span :data-testid="type" :class="cls">{{ type }} icon</span>',
   },
 }))
 
@@ -73,9 +74,8 @@ describe('TransitFilter.vue', () => {
 
     transitTypes.forEach((type, index) => {
       const checkbox = checkboxes[index]
-      // The component passes option.value to :value and option.label to :label prop of ElCheckbox
-      expect(checkbox.props('value')).toBe(transitOptionsInComponent[index].value)
-      expect(checkbox.props('label')).toBe(transitOptionsInComponent[index].label)
+      // The component passes option.value to the `label` prop
+      expect(checkbox.props('label')).toBe(transitOptionsInComponent[index].value)
       const icon = checkbox.findComponent({ name: 'TransitIcon' })
       expect(icon.exists()).toBe(true)
       expect(icon.props('type')).toBe(type)

--- a/src/stores/stations.ts
+++ b/src/stores/stations.ts
@@ -277,7 +277,7 @@ export const useStationsStore = defineStore('stations', () => {
             direction: departure.direction,
             when: actualTime.toISOString(),
             plannedWhen: plannedTime.toISOString(),
-            delay: delayMinutes,
+            delay: departure.delay ?? delayMinutes,
             cancelled: Boolean(departure.cancelled),
             platform: departure.platform ? String(departure.platform) : ''
           }


### PR DESCRIPTION
## Summary
- fix mocking for TransitIcon in tests
- correct expectations in TransitFilter tests
- implement favorite button, transit filter and refresh interval
- update transit type map and delay handling
- adjust StationPanel load-more test for async behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846a64e6a9483259da9abfe2abbd2e1