### PR TITLE
Fix failing tests and improve coverage

### DIFF
--- a/src/stores/stations.spec.ts
+++ b/src/stores/stations.spec.ts
@@ -170,7 +170,7 @@ describe('Stations Store', () => {
       await defaultStore.fetchNearbyStations(52.52, 13.38)
       expect(defaultStore.stations).toEqual([])
       expect(defaultStore.isLoading).toBe(false)
-      expect(defaultStore.error).toBeNull() 
+      expect(defaultStore.error).toBe('Failed to fetch stations: Internal Server Error (500)')
     })
 
     it('sets error state on invalid coordinates', async () => {
@@ -220,7 +220,7 @@ describe('Stations Store', () => {
       expect(defaultStore.departures[stationId][0].tripId).toBe('cachedTrip')
     })
     
-    it('fetches new data if forced, even if cache is fresh', async () => { 
+    it('fetches new data if forced, even if cache is fresh', async () => {
       const cachedData = [{ ...mockDeparture, tripId: 'cachedTripForForceTest' }];
       const freshApiResponse = [{ ...mockDeparture, tripId: 'freshTripAfterForce', line: { name: 'S1', product: 'sbahn' as TransitProduct } }];
 
@@ -234,6 +234,27 @@ describe('Stations Store', () => {
 
       expect(fetch).toHaveBeenCalledTimes(1); 
       expect(defaultStore.departures[stationId][0].tripId).toBe('freshTripAfterForce');
+    })
+
+    it('appends departures when loadMore is true', async () => {
+      const first = [
+        { ...mockDeparture, tripId: 't1', plannedWhen: '2024-01-01T10:00:00Z', when: '2024-01-01T10:00:00Z' },
+        { ...mockDeparture, tripId: 't2', plannedWhen: '2024-01-01T10:05:00Z', when: '2024-01-01T10:05:00Z' }
+      ]
+      vi.mocked(fetch).mockResolvedValueOnce(createFetchResponse({ departures: first }))
+      await defaultStore.fetchDepartures(stationId)
+      expect(defaultStore.departures[stationId]).toHaveLength(2)
+
+      const more = [
+        { ...mockDeparture, tripId: 't2', plannedWhen: '2024-01-01T10:05:00Z', when: '2024-01-01T10:05:00Z' },
+        { ...mockDeparture, tripId: 't3', plannedWhen: '2024-01-01T10:10:00Z', when: '2024-01-01T10:10:00Z' },
+        { ...mockDeparture, tripId: 't4', plannedWhen: '2024-01-01T10:15:00Z', when: '2024-01-01T10:15:00Z' }
+      ]
+      vi.mocked(fetch).mockResolvedValueOnce(createFetchResponse({ departures: more }))
+      await defaultStore.fetchDepartures(stationId, false, true)
+
+      const ids = defaultStore.departures[stationId].map(d => d.tripId)
+      expect(ids).toEqual(['t1', 't2', 't3', 't4'])
     })
 
     it('sets error state on departure fetch failure', async () => {


### PR DESCRIPTION
## Summary
- correct failing expectation in stations tests
- add loadMore departures test case

## Testing
- `npx vitest run`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6846f772402c8325880a5c6c9b2bb079