### PR TITLE
Improve test coverage

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import App from './App.vue'
+
+vi.mock('@vueuse/core', async () => {
+  const actual = await vi.importActual('@vueuse/core')
+  return {
+    ...actual,
+    useGeolocation: vi.fn(() => ({ coords: ref({ latitude: null, longitude: null }), isSupported: false })),
+    usePreferredDark: vi.fn(() => ref(false)),
+    useStorage: vi.fn((key: string, value: any) => ref(value))
+  }
+})
+
+vi.mock('./stores/stations', () => ({ useStationsStore: vi.fn(() => ({ fetchNearbyStations: vi.fn() })) }))
+vi.mock('./stores/favorites', () => ({ useFavoritesStore: vi.fn(() => ({})) }))
+vi.mock('leaflet', () => ({ default: { Icon: { Default: { mergeOptions: vi.fn(), prototype: {} } } } }))
+
+describe('App.vue', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows geolocation unsupported error', () => {
+    const wrapper = mount(App, { shallow: true })
+    expect(wrapper.text()).toContain('Geolocation is not supported')
+  })
+
+  it('handleReload triggers page reload', () => {
+    const wrapper = mount(App, { shallow: true })
+    const original = window.location.reload
+    Object.defineProperty(window, 'location', { value: { ...window.location, reload: vi.fn() }, writable: true })
+    ;(wrapper.vm as any).handleReload()
+    expect(window.location.reload).toHaveBeenCalled()
+    Object.defineProperty(window, 'location', { value: { ...window.location, reload: original } })
+  })
+
+  it('clearLocalStorage clears storage and reloads', () => {
+    const wrapper = mount(App, { shallow: true })
+    const original = window.location.reload
+    Object.defineProperty(window, 'location', { value: { ...window.location, reload: vi.fn() }, writable: true })
+    ;(wrapper.vm as any).clearLocalStorage()
+    expect(window.location.reload).toHaveBeenCalled()
+    Object.defineProperty(window, 'location', { value: { ...window.location, reload: original } })
+  })
+})

--- a/src/stores/helpers.spec.ts
+++ b/src/stores/helpers.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { isValidCoordinates, isValidStation, normalizeTransitType, normalizeStation } from './helpers'
+import type { VBBLocation } from '../types'
+
+describe('helpers', () => {
+  describe('isValidCoordinates', () => {
+    it('accepts valid latitude and longitude', () => {
+      const result = isValidCoordinates({ latitude: 52.5, longitude: 13.4 })
+      expect(result).toBe(true)
+    })
+
+    it('rejects invalid values', () => {
+      const result = isValidCoordinates({ latitude: 100, longitude: NaN })
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('normalizeTransitType', () => {
+    const cases = [
+      ['suburban', 'sbahn'],
+      ['s', 'sbahn'],
+      ['subway', 'ubahn'],
+      ['u', 'ubahn'],
+      ['tram', 'tram'],
+      ['bus', 'bus'],
+      ['ferry', 'ferry'],
+      ['unknown', 'bus']
+    ] as const
+
+    cases.forEach(([input, expected]) => {
+      it(`maps ${input} to ${expected}`, () => {
+        expect(normalizeTransitType(input)).toBe(expected)
+      })
+    })
+  })
+
+  describe('normalizeStation', () => {
+    it('strips city suffix and copies fields', () => {
+      const station: VBBLocation = {
+        type: 'stop',
+        id: '1',
+        name: 'Alex (Berlin)',
+        location: { type: 'location', latitude: 1, longitude: 2 }
+      }
+      const normalized = normalizeStation(station)
+      expect(normalized.name).toBe('Alex')
+      expect(normalized.id).toBe('1')
+      expect(normalized.location.latitude).toBe(1)
+    })
+  })
+
+  describe('isValidStation', () => {
+    it('detects missing data', () => {
+      const bad = { type: 'stop', id: 'x', name: '', location: { type: 'loc', latitude: undefined as any, longitude: 5 } } as unknown as VBBLocation
+      expect(isValidStation(bad)).toBe(false)
+    })
+
+    it('returns true for valid data', () => {
+      const good = { type: 'stop', id: '1', name: 'Foo', location: { type: 'loc', latitude: 1, longitude: 2 } } as VBBLocation
+      expect(isValidStation(good)).toBe(true)
+    })
+  })
+})

--- a/src/stores/helpers.ts
+++ b/src/stores/helpers.ts
@@ -1,0 +1,45 @@
+import type { VBBLocation, Station } from '../types'
+import type { TransitType } from '../types/preferences'
+
+export function isValidCoordinates(coords: { latitude?: number; longitude?: number } | null): coords is { latitude: number; longitude: number } {
+  return coords !== null &&
+    typeof coords.latitude === 'number' &&
+    typeof coords.longitude === 'number' &&
+    !isNaN(coords.latitude) &&
+    !isNaN(coords.longitude) &&
+    Math.abs(coords.latitude) <= 90 &&
+    Math.abs(coords.longitude) <= 180
+}
+
+export function isValidStation(station: VBBLocation): boolean {
+  return !!station &&
+    typeof station.name === 'string' &&
+    !!station.location &&
+    typeof station.location.latitude === 'number' &&
+    typeof station.location.longitude === 'number'
+}
+
+export function normalizeTransitType(type: string | undefined): TransitType {
+  const normalizedType = (type || '').toLowerCase()
+  if (normalizedType.includes('suburban') || normalizedType === 's') return 'sbahn'
+  if (normalizedType.includes('subway') || normalizedType === 'u') return 'ubahn'
+  if (normalizedType.includes('tram')) return 'tram'
+  if (normalizedType.includes('bus')) return 'bus'
+  if (normalizedType.includes('ferry')) return 'ferry'
+  return 'bus'
+}
+
+export function normalizeStation(station: VBBLocation): Station {
+  const { id, name, type, location } = station
+  return {
+    id,
+    name: name.replace(' (Berlin)', '').trim(),
+    type,
+    location: {
+      type: location.type,
+      latitude: location.latitude,
+      longitude: location.longitude
+    },
+    distance: undefined
+  }
+}

--- a/src/stores/stations.spec.ts
+++ b/src/stores/stations.spec.ts
@@ -258,11 +258,20 @@ describe('Stations Store', () => {
     })
 
     it('sets error state on departure fetch failure', async () => {
-      defaultStore.clearStations(); 
+      defaultStore.clearStations();
       vi.mocked(fetch).mockResolvedValue(createFetchResponse({}, false, 500, 'Server Down'))
       await defaultStore.fetchDepartures(stationId)
       expect(defaultStore.departures[stationId]).toEqual([])
       expect(defaultStore.error).toBe('Failed to fetch departures: Server Down')
+    })
+
+    it('handles AbortError gracefully', async () => {
+      const abortError = new Error('abort')
+      abortError.name = 'AbortError'
+      vi.mocked(fetch).mockRejectedValueOnce(abortError)
+      await defaultStore.fetchDepartures(stationId)
+      expect(defaultStore.departures[stationId]).toBeUndefined()
+      expect(defaultStore.error).toBeNull()
     })
   })
 

--- a/src/stores/stations.ts
+++ b/src/stores/stations.ts
@@ -6,6 +6,12 @@ import type { TransitType } from '../types/preferences'
 import { usePreferencesStore } from './preferences'
 import { useFavoritesStore } from './favorites'
 import { calculateDistance } from '../utils/distance'
+import {
+  isValidCoordinates,
+  isValidStation,
+  normalizeTransitType,
+  normalizeStation,
+} from './helpers'
 
 interface DepartureCache {
   data: Trip[]
@@ -54,15 +60,6 @@ export const useStationsStore = defineStore('stations', () => {
     { immediate: true }
   )
   
-  function isValidCoordinates(coords: { latitude?: number; longitude?: number } | null): coords is { latitude: number; longitude: number } {
-    return coords !== null &&
-           typeof coords.latitude === 'number' &&
-           typeof coords.longitude === 'number' &&
-           !isNaN(coords.latitude) &&
-           !isNaN(coords.longitude) &&
-           Math.abs(coords.latitude) <= 90 &&
-           Math.abs(coords.longitude) <= 180
-  }
 
   const sortedStations = computed(() => {
     const { userLocation, mapCenter, stations } = state.value
@@ -350,38 +347,6 @@ export const useStationsStore = defineStore('stations', () => {
     }
   }
 
-  function isValidStation(station: VBBLocation): boolean {
-    return !!station &&
-           typeof station.name === 'string' &&
-           !!station.location &&
-           typeof station.location.latitude === 'number' &&
-           typeof station.location.longitude === 'number'
-  }
-
-  function normalizeTransitType(type: string | undefined): TransitType {
-    const normalizedType = (type || '').toLowerCase()
-    if (normalizedType.includes('suburban') || normalizedType === 's') return 'sbahn'
-    if (normalizedType.includes('subway') || normalizedType === 'u') return 'ubahn'
-    if (normalizedType.includes('tram')) return 'tram'
-    if (normalizedType.includes('bus')) return 'bus'
-    if (normalizedType.includes('ferry')) return 'ferry'
-    return 'bus' // default to bus if unknown
-  }
-
-  function normalizeStation(station: VBBLocation): Station {
-    const { id, name, type, location } = station
-    return {
-      id,
-      name: name.replace(' (Berlin)', '').trim(),
-      type,
-      location: {
-        type: location.type,
-        latitude: location.latitude,
-        longitude: location.longitude
-      },
-      distance: undefined
-    }
-  }
 
   return {
     stations: computed(() => state.value.stations),


### PR DESCRIPTION
## Summary
- extract helper functions for stations store
- add unit tests for helper utilities
- add tests for store abort behavior
- test App.vue interactions

## Testing
- `npx vitest run`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68652afec7a88325a3f3125b87f13102