### PR TITLE
Add semver tagging to container build

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*.*.*'
 
 permissions:
   contents: read
@@ -16,6 +18,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -26,17 +33,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine release version
+        id: version
+        run: |
+          TAG=$(git tag --points-at HEAD | head -n 1)
+          if [ -n "$TAG" ]; then
+            VERSION=$TAG
+          else
+            VERSION=v$(node -p "require('./package.json').version")
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Build Docker image
         run: |
           IMAGE=ghcr.io/${{ github.repository }}
           IMAGE=$(echo "$IMAGE" | tr '[:upper:]' '[:lower:]')
-          docker build -t $IMAGE:latest -t $IMAGE:${{ github.sha }} .
+          docker build -t $IMAGE:latest -t $IMAGE:${{ env.VERSION }} .
           echo "IMAGE=$IMAGE" >> $GITHUB_ENV
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@0.31.0
         with:
-          image-ref: ${{ env.IMAGE }}:${{ github.sha }}
+          image-ref: ${{ env.IMAGE }}:${{ env.VERSION }}
           format: table
           exit-code: '1'
           ignore-unfixed: true
@@ -45,6 +63,6 @@ jobs:
 
       - name: Push Docker image
         run: |
-          docker push $IMAGE:${{ github.sha }}
+          docker push $IMAGE:${{ env.VERSION }}
           docker push $IMAGE:latest
 


### PR DESCRIPTION
## Summary
- handle tag-triggered builds for container image
- setup Node.js for release version extraction
- use git tag or package.json version for container tags

## Testing
- `npm ci`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6865330015508325b314e1491e9b9ea4