### PR TITLE
Fix long names pushing times off screen

### DIFF
--- a/src/components/StationPanel.vue
+++ b/src/components/StationPanel.vue
@@ -174,13 +174,13 @@ function toggleFavorite() {
         </div>
         
         <div class="flex-1 mx-4">
-          <div class="font-medium truncate">{{ departure.direction }}</div>
+          <div class="font-medium break-words whitespace-normal">{{ departure.direction }}</div>
           <div class="text-sm text-gray-500 dark:text-dark-secondary">
             {{ departure.platform ? `Platform ${departure.platform}` : '' }}
           </div>
         </div>
         
-        <div class="text-right">
+        <div class="text-right flex-shrink-0 w-16">
           <div class="font-medium">
             {{ departure.formattedTime }}
           </div>


### PR DESCRIPTION
## Summary
- prevent long station names from shifting departure times
- update departure layout to wrap station names and keep times visible

## Testing
- `npm install`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68654393ecdc8325b30303eb8486c34b