### PR TITLE
Fix mobile departure row layout

### DIFF
--- a/src/components/StationPanel.vue
+++ b/src/components/StationPanel.vue
@@ -173,7 +173,8 @@ function toggleFavorite() {
           {{ departure.line.name }}
         </div>
         
-        <div class="flex-1 mx-4">
+        <!-- Allow the direction text to shrink on small screens so the time stays visible -->
+        <div class="flex-1 mx-4 min-w-0">
           <div class="font-medium truncate">{{ departure.direction }}</div>
           <div class="text-sm text-gray-500 dark:text-dark-secondary">
             {{ departure.platform ? `Platform ${departure.platform}` : '' }}


### PR DESCRIPTION
## Summary
- keep departure times visible on small screens by letting direction text shrink
- add tests dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68654393ecdc8325b30303eb8486c34b