### PR TITLE
feat: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Needed for git tag-based versioning
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update version from git tags
+        run: npm run prebuild
+
+      - name: Build application
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Add automatic deployment to GitHub Pages to ensure the live site always shows the latest version with correct git tag-based versioning.

## Problem Solved
- 🐛 **Live site showing no version**: The current live site at transit.niepi.org doesn't show version information
- 🔄 **Manual deployment**: No automatic deployment when main branch is updated
- 📦 **Version sync**: Ensure live site uses git tag-based versioning system

## Changes Made
- **GitHub Pages Deployment**: Automatic deployment on main branch pushes
- **Version Integration**: Includes `npm run prebuild` to update version from git tags
- **Manual Trigger**: Workflow can be manually triggered via GitHub UI
- **Proper Permissions**: Setup Pages permissions for deployment

## Benefits
- ✅ **Automatic Updates**: Live site updates on every main branch push
- ✅ **Correct Versioning**: Git tag-based version system works on live site  
- ✅ **Manual Control**: Can manually trigger deployment when needed
- ✅ **Version Display**: Live site will now show correct version (v0.5.1)

## Testing
Once merged, this will:
1. Deploy the current version (v0.5.1) to GitHub Pages
2. Show the correct version in the live app UI
3. Automatically deploy future updates

🎯 This fixes the version display issue on the live site and sets up proper continuous deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)